### PR TITLE
Update publish-release.sh

### DIFF
--- a/Scripts/publish-release.sh
+++ b/Scripts/publish-release.sh
@@ -20,7 +20,7 @@ if [ "$(git rev-parse --abbrev-ref HEAD)" != main ]; then
 fi
 
 # ensure we have the latest version tags
-git fetch origin -pft
+git fetch origin --prune --tags
 
 versions="$(git tag | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+')"
 v_latest="$(npx -- semver --include-prerelease $versions | tail -n1)"


### PR DESCRIPTION
The script contains a potential typo in the git fetch ? 

The option -pft does not exist in git fetch. Commonly used options include -p (prune) or --tags 

Correct command would be -> git fetch origin -p --force --tags