### PR TITLE
Universal builds (intel mac support)

### DIFF
--- a/Scripts/install-docker.sh
+++ b/Scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if ! test -d /Applications/Docker.app; then
-    /opt/homebrew/bin/brew install --cask Docker
+    brew install --cask Docker
 else
-    /opt/homebrew/bin/brew uninstall --cask Docker
+    brew uninstall --cask Docker
 fi

--- a/Sources/teaBASE.h
+++ b/Sources/teaBASE.h
@@ -83,3 +83,4 @@ BOOL file_contains(NSString *path, NSString *token);
 BOOL sudo_run_cmd(char *cmd, char *arguments[], NSString *errorTitle);
 NSString *output(NSString *cmd, NSArray *args);
 NSString *which(NSString *cmd);
+NSString *brewPath(void);

--- a/Sources/teaBASE.m
+++ b/Sources/teaBASE.m
@@ -121,7 +121,7 @@
 }
 
 - (void)updateVersions {
-    NSString *brew_out = output(@"/opt/homebrew/bin/brew", @[@"--version"]);
+    NSString *brew_out = output(brewPath(), @[@"--version"]);
     NSString *pkgx_out = output(@"/usr/local/bin/pkgx", @[@"--version"]);
     NSString *xcode_clt_out = output(@"/usr/sbin/pkgutil", @[@"--pkg-info=com.apple.pkg.CLTools_Executables"]);
     
@@ -161,7 +161,7 @@
 }
 
 - (BOOL)homebrewInstalled {
-    return [NSFileManager.defaultManager isReadableFileAtPath:@"/opt/homebrew/bin/brew"];
+    return [NSFileManager.defaultManager isReadableFileAtPath:brewPath()];
 }
 
 - (BOOL)pkgxInstalled {
@@ -555,6 +555,7 @@
             [self.brewInstallWindowSpinner stopAnimation:sender];
         }];
     } else {
+    #if __arm64
         // Get the contents of the directory
         NSError *error = nil;
         NSArray *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:@"/opt/homebrew" error:&error];
@@ -576,6 +577,12 @@
         }
         
         [self updateVersions];
+    #else
+        NSAlert *alert = [NSAlert new];
+        alert.informativeText = @"Please manually run the Homebrew uninstall script";
+        [alert runModal];
+        [sender setState:NSControlStateValueOn];
+    #endif
     }
 }
 
@@ -610,7 +617,7 @@ static BOOL installer(NSURL *url) {
                 
                 if (self.setupBrewShellEnvCheckbox.state == NSControlStateValueOn) {
                     NSString *zprofilePath = [NSHomeDirectory() stringByAppendingPathComponent:@".zprofile"];
-                    NSString *cmdline = @"eval \"$(/opt/homebrew/bin/brew shellenv)\"";
+                    NSString *cmdline = [NSString stringWithFormat:@"eval \"$(%@ shellenv)\"", brewPath()];
                     
                     BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:zprofilePath];
                     
@@ -705,7 +712,7 @@ static BOOL installer(NSURL *url) {
         // for weird reasons the install window does not come to the front on Somona
         run(@"/usr/bin/open", @[@"/System/Library/CoreServices/Install Command Line Developer Tools.app"], nil);
     } else {
-        run(@"/opt/homebrew/bin/brew", @[@"install", @"git"], nil);
+        run(brewPath(), @[@"install", @"git"], nil);
     }
 }
 

--- a/teaBASE.xcodeproj/project.pbxproj
+++ b/teaBASE.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		6367D7312CDD28E300250E84 /* github-integration.sh in Copy Scripts to Bundle */ = {isa = PBXBuildFile; fileRef = 6367D72E2CDD28CA00250E84 /* github-integration.sh */; };
 		63AA5EC82CEF5C6300BC8696 /* usr-local-install.sh in Copy Scripts to Bundle */ = {isa = PBXBuildFile; fileRef = 63AA5EC62CEF59DD00BC8696 /* usr-local-install.sh */; };
 		63AE66812CF618DC00EB278B /* docker-version.sh in Copy Scripts to Bundle */ = {isa = PBXBuildFile; fileRef = 63AE667F2CF6173D00EB278B /* docker-version.sh */; };
-		63FCE92D2D061C1B000DA22F /* install-docker.sh in Resources */ = {isa = PBXBuildFile; fileRef = 63FCE92C2D061C15000DA22F /* install-docker.sh */; };
 		63FCE92E2D061CE1000DA22F /* install-docker.sh in Copy Scripts to Bundle */ = {isa = PBXBuildFile; fileRef = 63FCE92C2D061C15000DA22F /* install-docker.sh */; };
 		63FF33402D07CDFF0021E1E2 /* self-update.sh in Copy Scripts to Bundle */ = {isa = PBXBuildFile; fileRef = 632E38D82D01C60C00B7A044 /* self-update.sh */; };
 /* End PBXBuildFile section */
@@ -213,7 +212,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				63FCE92D2D061C1B000DA22F /* install-docker.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -240,7 +238,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "set -exo pipefail\n\ncd \"${DERIVED_FILE_DIR}\"\n\ncp pkgx \"${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}\"\ncp bpb \"${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}\"\n";
+			shellScript = "set -exo pipefail\n\ncd \"${DERIVED_FILE_DIR}\"\n\ncp pkgx \"${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}\"\ncp bpb/target/release/bpb \"${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}\"\n";
 		};
 		63AE66822CF754D200EB278B /* Build bpb */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -256,11 +254,12 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/bpb",
+				"$(DERIVED_FILE_DIR)/bpb/target/release/bpb",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Xcode sandboxes these scripts so only files you can specify as outputs can be created, lol ffs\ncd /tmp\n\nif ! test -d bpb/.git; then\n    git clone https://github.com/pkgxdev/bpb\n    cd bpb\nelse\n    cd bpb\n    git fetch -pft\n    git reset --hard origin/main\nfi\n\n\"${DERIVED_FILE_DIR}\"/pkgx cargo build --release\nmv target/release/bpb \"${DERIVED_FILE_DIR}\" \n";
+			shellScript = "# Xcode sandboxes these scripts so only files you can specify as outputs can be created, lol ffs\ncd \"$DERIVED_FILE_DIR\"\n\nif ! test -d bpb/.git; then\n    rm -rf bpb  # Xcode tries to be helpful by creating the intermediary directories for us but this breaks git clone\n    git clone https://github.com/pkgxdev/bpb\n    cd bpb\nelse\n    cd bpb\n    git fetch -pft\n    git reset --hard origin/main\nfi\n\n\"${DERIVED_FILE_DIR}\"/pkgx cargo build --release\n";
+			showEnvVarsInLog = 0;
 		};
 		63B188092CBD6AE30081E570 /* Download pkgx */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -305,6 +304,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 7WV56FL599;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Sundries/Info.plist;
 				INFOPLIST_KEY_NSMainNibFile = teaBASE;
@@ -333,6 +333,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 7WV56FL599;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Sundries/Info.plist;
 				INFOPLIST_KEY_NSMainNibFile = teaBASE;


### PR DESCRIPTION
Notably this involves lipo’ing pkgx into a whopper binary of 180MB. Not great. We could strip the unused binary bits away when installing. For another day.