### PR TITLE
Improve Emergency Kit PDF readability

### DIFF
--- a/Sources/teaBASE.m
+++ b/Sources/teaBASE.m
@@ -341,7 +341,23 @@
         return;
     }
 
-    content = [NSString stringWithFormat:@"Recreate the following at: `~/.ssh/%@.pub`:\n\n%@", filename, content];
+    // Break the pubkic key content into 70-char lines (aligned with the private key visually) to make it fit the page
+    NSMutableString *formattedContent = [NSMutableString string];
+    NSUInteger lineLength = 70;
+    NSUInteger currentIndex = 0;
+    
+    while (currentIndex < content.length) {
+        NSUInteger remainingLength = content.length - currentIndex;
+        NSUInteger substringLength = MIN(lineLength, remainingLength);
+        NSRange range = NSMakeRange(currentIndex, substringLength);
+        
+        [formattedContent appendString:[content substringWithRange:range]];
+        [formattedContent appendString:@"\n"];
+        
+        currentIndex += substringLength;
+    }
+    
+    content = [NSString stringWithFormat:@"Recreate the following at: `~/.ssh/%@.pub`:\n\n%@", filename, formattedContent];
     
     NSString *privkey_content = [NSString stringWithContentsOfFile:privkey_path encoding:NSUTF8StringEncoding error:&error];
     
@@ -363,6 +379,11 @@
     // Create an NSTextView and set the document content
     NSTextView *textView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, 612, 612)]; // Typical page size
     [textView setString:content];
+
+    // Set font to Menlo (monospace) and make it smaller in order to fit the page
+    NSFont *monoFont = [NSFont fontWithName:@"Menlo" size:10.4];
+    [textView setFont:monoFont];
+    [[textView textStorage] setFont:monoFont]; // Ensure the entire text storage uses the font
     
     // Configure the print operation for the text view
     NSPrintOperation *printOperation = [NSPrintOperation printOperationWithView:textView];
@@ -563,6 +584,11 @@
     // Create an NSTextView and set the document content
     NSTextView *textView = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, 612, 612)]; // Typical page size
     [textView setString:content];
+    
+    // Set font to Menlo (monospace) and make it smaller in order to fit the page
+    NSFont *monoFont = [NSFont fontWithName:@"Menlo" size:9.6];
+    [textView setFont:monoFont];
+    [[textView textStorage] setFont:monoFont]; // Ensure the entire text storage uses the font
     
     // Configure the print operation for the text view
     NSPrintOperation *printOperation = [NSPrintOperation printOperationWithView:textView];


### PR DESCRIPTION
## Changes
- Added Menlo monospace font styling to emergency kit PDFs (Both GPG and SSH)
- Set smaller font size for optimal key display on a paper
- Break down ed25519 public key into 70-char lines to match private key width _on a paper_

## Why
The emergency kit PDFs contain cryptographic keys that are better displayed in a monospace font for improved readability and accurate character alignment. This is particularly important when users need to manually transcribe or verify these keys.

The ed25519 public key is too long to fit on a single line when printed. 
Breaking it into 70-character chunks that align with the OpenSSH private key format makes the output more consistent and easier to read, preventing any confusion between line breaks and actual key content.