### PR TITLE
Improve Xcode and Command Line Tools Detection

### DIFF
--- a/Sources/teaBASE.m
+++ b/Sources/teaBASE.m
@@ -134,31 +134,43 @@
     [task launchAndReturnError:&error];
     
     if (error) {
+        NSLog(@"teaBASE: xcodeCLTInstalled [error]: %@", error);
         return NO;
     }
     
     [task waitUntilExit];
+
+    NSLog(@"teaBASE: xcodeCLTInstalled [output]: %d", task.terminationStatus);
+
     return task.terminationStatus == 0;
 }
 
 - (BOOL)xcodeInstalled {
     NSTask *task = [[NSTask alloc] init];
-    [task setLaunchPath:@"/usr/bin/xcodebuild"];
-    [task setArguments:@[@"-version"]];
+    [task setLaunchPath:@"/usr/bin/mdfind"];
+    [task setArguments:@[@"kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'"]];
     
-    NSPipe *nullPipe = [NSPipe pipe];
-    [task setStandardOutput:nullPipe];
-    [task setStandardError:nullPipe];
+    NSPipe *pipe = [NSPipe pipe];
+    [task setStandardOutput:pipe];
+    [task setStandardError:pipe];
     
     NSError *error = nil;
     [task launchAndReturnError:&error];
     
     if (error) {
+        NSLog(@"teaBASE: xcodeInstalled [error]: %@", error);
         return NO;
     }
     
+    NSFileHandle *fileHandle = [pipe fileHandleForReading];
+    NSData *data = [fileHandle readDataToEndOfFile];
+    NSString *output = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    
     [task waitUntilExit];
-    return task.terminationStatus == 0;
+
+    NSLog(@"teaBASE: xcodeInstalled [output]: %@", output);
+
+    return output.length > 0;
 }
 
 - (void)updateVersions {

--- a/Sources/teaBASE.m
+++ b/Sources/teaBASE.m
@@ -122,14 +122,23 @@
 }
 
 - (BOOL)xcodeCLTInstalled {
-    if ([NSFileManager.defaultManager isExecutableFileAtPath:@"/Library/Developer/CommandLineTools/usr/bin/git"]) {
-        return YES;
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/usr/bin/xcode-select"];
+    [task setArguments:@[@"-p"]];
+    
+    NSPipe *nullPipe = [NSPipe pipe];
+    [task setStandardOutput:nullPipe];
+    [task setStandardError:nullPipe];
+    
+    NSError *error = nil;
+    [task launchAndReturnError:&error];
+    
+    if (error) {
+        return NO;
     }
-    //TODO Xcode can be installed anywhere, instead check for the bundle ID with spotlight API or mdfind
-    if ([NSFileManager.defaultManager isExecutableFileAtPath:@"/Applications/Xcode.app"]) {
-        return YES;
-    }
-    return NO;
+    
+    [task waitUntilExit];
+    return task.terminationStatus == 0;
 }
 
 - (void)updateVersions {

--- a/Sources/teaBASE.m
+++ b/Sources/teaBASE.m
@@ -150,7 +150,7 @@
 
     NSString *docker_version = output(path, @[]);
     
-    BOOL has_clt = [NSFileManager.defaultManager isExecutableFileAtPath:@"/Library/Developer/CommandLineTools/usr/bin/git"];
+    BOOL has_clt = [self xcodeCLTInstalled];
     //TODO Xcode can be installed anywhere, instead check for the bundle ID with spotlight API or mdfind
     BOOL has_xcode = [NSFileManager.defaultManager isExecutableFileAtPath:@"/Applications/Xcode.app"];
     // emulate login shell to ensure PATH contains everything the user has configured

--- a/Sources/teaBASE.m
+++ b/Sources/teaBASE.m
@@ -141,6 +141,26 @@
     return task.terminationStatus == 0;
 }
 
+- (BOOL)xcodeInstalled {
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/usr/bin/xcodebuild"];
+    [task setArguments:@[@"-version"]];
+    
+    NSPipe *nullPipe = [NSPipe pipe];
+    [task setStandardOutput:nullPipe];
+    [task setStandardError:nullPipe];
+    
+    NSError *error = nil;
+    [task launchAndReturnError:&error];
+    
+    if (error) {
+        return NO;
+    }
+    
+    [task waitUntilExit];
+    return task.terminationStatus == 0;
+}
+
 - (void)updateVersions {
     NSString *brew_out = output(brewPath(), @[@"--version"]);
     NSString *pkgx_out = output(@"/usr/local/bin/pkgx", @[@"--version"]);
@@ -151,8 +171,7 @@
     NSString *docker_version = output(path, @[]);
     
     BOOL has_clt = [self xcodeCLTInstalled];
-    //TODO Xcode can be installed anywhere, instead check for the bundle ID with spotlight API or mdfind
-    BOOL has_xcode = [NSFileManager.defaultManager isExecutableFileAtPath:@"/Applications/Xcode.app"];
+    BOOL has_xcode = [self xcodeInstalled];
     // emulate login shell to ensure PATH contains everything the user has configured
     // ∵ GUI apps do not have full user PATH set otherwise
     NSString *git_out = nil;


### PR DESCRIPTION
## Changes

- Replace path-based Command Line Tools detection with `xcode-select -p`
- Add new `xcodeInstalled` method using `xcodebuild -version` for Xcode detection
- Refactor code to use these new methods consistently throughout the codebase

## Why

The previous implementation relied on checking specific file paths:
- `/Library/Developer/CommandLineTools/usr/bin/git` for CLT
- `/Applications/Xcode.app` for Xcode

This approach was unreliable because:
1. Xcode can be installed in different locations
2. Path checking doesn't verify if the installation is functional
3. Future macOS versions might change these paths