### PR TITLE
Adjust version number contrast

### DIFF
--- a/Sources/Base.lproj/teaBASE.xib
+++ b/Sources/Base.lproj/teaBASE.xib
@@ -997,7 +997,7 @@
                         <rect key="frame" x="436" y="20" width="36" height="14"/>
                         <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="v0.0.0" id="grM-PD-0I7">
                             <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" name="quaternaryLabelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="tertiaryLabelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>


### PR DESCRIPTION
## Changes
- Adjusted the color of the version number display from `quaternaryLabelColor` to `tertiaryLabelColor`
- Updated the .xib directly to avoid massive code changes

## Why
The original color was too light to see

Closes #19