### PR TITLE
Fix automatic window opening when switching to preference pane

### DIFF
--- a/Sources/teaBASE.m
+++ b/Sources/teaBASE.m
@@ -9,6 +9,9 @@
 }
 
 - (void)willSelect {
+    // Close any open windows from previous pane
+    [self closeAllWindows];
+    
     // Initially disable all interactive elements
     [self.gpgSignSwitch setEnabled:NO];
     [self.homebrewSwitch setEnabled:NO];
@@ -91,6 +94,16 @@
             self.selfVersionLabel.stringValue = [NSString stringWithFormat:@"v%@", v];
         }
     });
+}
+
+- (void)closeAllWindows {
+    // Close all modal windows when switching panes
+    [self.sshPassphraseWindow close];
+    [self.sshRemovePassphraseWindow close];
+    [self.gpgPassphraseWindow close];
+    [self.brewInstallWindow close];
+    [self.gitGudWindow close];
+    [self.gitIdentityWindow close];
 }
 
 - (void)didSelect {


### PR DESCRIPTION
## Description
When switching to teaBASE after another custom preference pane was open, all modal windows (SSH passphrase, GPG passphrase, Homebrew install, etc.) would automatically open at once. This behavior was unintended as these windows should only open on-demand when their respective features are accessed.

## Changes
- Added `closeAllWindows` method to explicitly manage window state
- Updated `willSelect` to call `closeAllWindows` before initializing the pane

Closes #29