### PR TITLE
Improve whitespace handling in file search

### DIFF
--- a/Sources/misc.m
+++ b/Sources/misc.m
@@ -103,9 +103,17 @@ BOOL file_contains(NSString *path, NSString *token) {
         return NO; // TODO error condition
     }
     
-    // FIXME whitespace can vary
-    NSRange range = [fileContents rangeOfString:token];
+    // Normalize whitespace in both strings before comparison
+    NSString *normalizedContents = [fileContents stringByReplacingOccurrencesOfString:@"\\s+"
+                                                                           withString:@" "
+                                                                              options:NSRegularExpressionSearch
+                                                                                range:NSMakeRange(0, fileContents.length)];
+    NSString *normalizedToken = [token stringByReplacingOccurrencesOfString:@"\\s+"
+                                                                 withString:@" "
+                                                                    options:NSRegularExpressionSearch
+                                                                      range:NSMakeRange(0, token.length)];
     
+    NSRange range = [normalizedContents rangeOfString:normalizedToken];
     return (range.location != NSNotFound);
 }
 

--- a/Sources/misc.m
+++ b/Sources/misc.m
@@ -104,14 +104,8 @@ BOOL file_contains(NSString *path, NSString *token) {
     }
     
     // Normalize whitespace in both strings before comparison
-    NSString *normalizedContents = [fileContents stringByReplacingOccurrencesOfString:@"\\s+"
-                                                                           withString:@" "
-                                                                              options:NSRegularExpressionSearch
-                                                                                range:NSMakeRange(0, fileContents.length)];
-    NSString *normalizedToken = [token stringByReplacingOccurrencesOfString:@"\\s+"
-                                                                 withString:@" "
-                                                                    options:NSRegularExpressionSearch
-                                                                      range:NSMakeRange(0, token.length)];
+    NSString *normalizedContents = [fileContents stringByReplacingOccurrencesOfString:@"\\s+" withString:@" " options:NSRegularExpressionSearch range:NSMakeRange(0, fileContents.length)];
+    NSString *normalizedToken = [token stringByReplacingOccurrencesOfString:@"\\s+" withString:@" " options:NSRegularExpressionSearch range:NSMakeRange(0, token.length)];
     
     NSRange range = [normalizedContents rangeOfString:normalizedToken];
     return (range.location != NSNotFound);


### PR DESCRIPTION
## Changes
- Added regex-based whitespace normalization
- Both search token and file contents are normalized before comparison
- Handles multiple spaces and tabs

## Example
- Before: `"UseKeychain yes"` would only match the exact token + whitespace
- After: `"UseKeychain yes"` now matches `"UseKeychain     yes"`, `"UseKeychain\tyes"`, etc.