### PR TITLE
Improve pkgx binary detection with multiple locations

### DIFF
--- a/Sources/teaBASE+Helpers.m
+++ b/Sources/teaBASE+Helpers.m
@@ -69,8 +69,18 @@
 }
 
 - (BOOL)pkgxInstalled {
-    //TODO need to check more locations
-    return [NSFileManager.defaultManager isReadableFileAtPath:@"/usr/local/bin/pkgx"];
+    NSArray *locations = @[
+        @"/usr/local/bin/pkgx", // system-wide
+        [NSString stringWithFormat:@"%@/.local/bin/pkgx", NSHomeDirectory()] // user-specific
+    ];
+    
+    NSFileManager *fm = NSFileManager.defaultManager;
+    for (NSString *path in locations) {
+        if ([fm isExecutableFileAtPath:path]) {
+            return YES;
+        }
+    }
+    return NO;
 }
 
 @end


### PR DESCRIPTION
## Changes
- Add support for detecting `pkgx` in user-specific installation path (`~/.local/bin`), according to [the pkgx installation script](https://github.com/pkgxdev/pkgx/blob/f28d9311eac07c0dd0b4c3900eab2420199b6604/src/modes/install.ts#L23)
- Switch to `isExecutableFileAtPath` for more accurate binary detection

## Why
1. Checking both possible installation locations, according to the installation script of `pkgx`
2. Ensuring the binary is actually executable, not just readable.