### PR TITLE
Fix Incorrect Escaping of the * Character in the find Command

### DIFF
--- a/Scripts/github-integration.sh
+++ b/Scripts/github-integration.sh
@@ -28,7 +28,7 @@ else
   gh auth login -h github.com -p https -s write:gpg_key -s admin:public_key -w
 fi
 
-if test $(find ~/.ssh -name id_\*.pub | wc -l) -gt 1; then
+if test $(find ~/.ssh -name id_*.pub | wc -l) -gt 1; then
   gum format \
     "# multiple ssh public keys found" \
     "choose which to upload" \


### PR DESCRIPTION
To correctly search for all files that start with id_ and end with .pub, you should use the pattern id_*.pub without escaping the * or enclose it in quotes to prevent shell expansion before executing the find command.