### PR TITLE
Fix: make "Clean Install Guide" text clickable

### DIFF
--- a/Sources/Base.lproj/teaBASE.xib
+++ b/Sources/Base.lproj/teaBASE.xib
@@ -1607,7 +1607,7 @@
                                         <action selector="generateCleanInstallPack:" target="-2" id="WPD-eG-zYx"/>
                                     </connections>
                                 </button>
-                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ful-lG-Ec9">
+                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ful-lG-Ec9" customClass="ClickableTextField">
                                     <rect key="frame" x="18" y="20" width="106" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Clean Install Guide " id="cU8-Jd-ARr">
                                         <font key="font" metaFont="smallSystem"/>

--- a/Sources/ClickableTextField.h
+++ b/Sources/ClickableTextField.h
@@ -1,0 +1,7 @@
+#import <Cocoa/Cocoa.h>
+
+@interface ClickableTextField : NSTextField
+
+@property (nonatomic, copy) void (^onClick)(void);
+
+@end

--- a/Sources/ClickableTextField.m
+++ b/Sources/ClickableTextField.m
@@ -1,0 +1,19 @@
+#import "ClickableTextField.h"
+
+@implementation ClickableTextField
+
+- (void)mouseDown:(NSEvent *)event {
+    if (self.onClick) {
+        self.onClick();
+    } else if (self.target && self.action) {
+        [self.target performSelector:self.action withObject:self];
+    }
+}
+
+// update the cursor to be a pointer
+- (void)resetCursorRects {
+    [super resetCursorRects];
+    [self addCursorRect:self.bounds cursor:[NSCursor pointingHandCursor]];
+}
+
+@end


### PR DESCRIPTION
## Issue
The **Clean Install Guide** text was implemented as a standard NSTextField, which doesn't receive click events.

## Solution
Created a custom `ClickableTextField` class that:
- Handles click events properly
- Shows a pointing hand cursor on hover for better UX
- Maintains the visual appearance of a text field

## Changes
- Added `ClickableTextField.h` and `ClickableTextField.m`
- Updated the class of the text "Clean Install Guide" directly in the .xib to minimize changes