### PR TITLE
fix: verify pkgx installation before generating clean install pack

### DIFF
--- a/Sources/teaBASE+CleanInstall.m
+++ b/Sources/teaBASE+CleanInstall.m
@@ -3,8 +3,29 @@
 @implementation teaBASE (CleanInstall)
 
 - (IBAction)generateCleanInstallPack:(id)sender {
-    NSString *script_path = [[[NSBundle bundleForClass:[self class]] bundlePath] stringByAppendingPathComponent:@"Contents/Scripts/make-clean-install-pack.command"];
+    if (![self pkgxInstalled]) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = @"pkgx Required";
+        alert.informativeText = @"pkgx is required to generate a clean install pack. Would you like to install it now?";
+        [alert addButtonWithTitle:@"Install"];
+        [alert addButtonWithTitle:@"Cancel"];
+        
+        NSModalResponse response = [alert runModal];
+        if (response == NSAlertFirstButtonReturn) {
+            [self installSubexecutable:@"pkgx"];
+            [self updateVersions];
 
+            // Update pkgx switch state
+            [self.pkgxSwitch setEnabled:YES];
+            [self.pkgxSwitch setState:NSControlStateValueOn];
+
+            // After installation, proceed with generating the pack
+            [self generateCleanInstallPack:sender];
+        }
+        return;
+    }
+    
+    NSString *script_path = [[[NSBundle bundleForClass:[self class]] bundlePath] stringByAppendingPathComponent:@"Contents/Scripts/make-clean-install-pack.command"];
     run(@"/usr/bin/open", @[script_path], nil);    
 }
 

--- a/Sources/teaBASE+CleanInstall.m
+++ b/Sources/teaBASE+CleanInstall.m
@@ -15,9 +15,9 @@
             [self installSubexecutable:@"pkgx"];
             [self updateVersions];
 
-            // Update pkgx switch state
+            // Update switch state based on actual installation status
             [self.pkgxSwitch setEnabled:YES];
-            [self.pkgxSwitch setState:NSControlStateValueOn];
+            [self.pkgxSwitch setState:[self pkgxInstalled] ? NSControlStateValueOn : NSControlStateValueOff];
 
             // After installation, proceed with generating the pack
             [self generateCleanInstallPack:sender];


### PR DESCRIPTION
## Issue
The clean install pack generation requires `pkgx` to be installed, but there was no validation about that.

## Changes
- Added `pkgx` installation check before generating clean install pack
- Implemented alert dialog to inform users if pkgx is not installed, and ask if they want to install
- Integrated with existing `pkgx` installation flow
- Update the pkgx switch button after installation
- Continue to the original flow after installation