### PR TITLE
Fix typo in customObjectInstantiationMethod attribute in teaBASE.xib

### DIFF
--- a/Sources/Base.lproj/teaBASE.xib
+++ b/Sources/Base.lproj/teaBASE.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantiationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>


### PR DESCRIPTION


---


**Description:**  
This pull request corrects a typo in the teaBASE.xib file, updating the attribute name from `customObjectInstintantiationMethod` to `customObjectInstantiationMethod` for improved accuracy and consistency.

---

